### PR TITLE
bug fix: [aida/tools/aida-evaluation] docker make build

### DIFF
--- a/tools/aida-evaluation/docker/Dockerfile
+++ b/tools/aida-evaluation/docker/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER shahzad.rajput@nist.gov
 RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
 
 # Install system packages
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt update && apt-get install -y \
     curl \
     git \
     make \


### PR DESCRIPTION
Closes #40. 

It may display the below warning: 

```
Reading package lists...

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```